### PR TITLE
Fix error taking address of rvalue

### DIFF
--- a/cpp/include/InetAddress.h
+++ b/cpp/include/InetAddress.h
@@ -165,7 +165,8 @@ namespace vrt {
      */
     inline void packInetAddr (void *ptr, int32_t off, const InetAddress &val) {
       char *buf = (char*)ptr;
-      memcpy(&buf[off], &val.toIPv6().s6_addr[0], 16);
+      auto addr = val.toIPv6().s6_addr[0];
+      memcpy(&buf[off], &addr, 16);
     }
 
     /** Pack a 16-byte IPv6 address into a buffer.
@@ -174,7 +175,8 @@ namespace vrt {
      *  @param val   value to pack [INPUT]
      */
     inline void packInetAddr (vector<char> &buf, int32_t off, const InetAddress &val) {
-      memcpy(&buf[off], &val.toIPv6().s6_addr[0], 16);
+      auto addr = val.toIPv6().s6_addr[0];
+      memcpy(&buf[off], &addr, 16);
     }
 
     /** Unpack a 16-byte IPv6 address from a buffer.


### PR DESCRIPTION
When building with g++ 10.2.1, I was getting "error: taking address of rvalue [-fpermissive]" on these two lines.